### PR TITLE
Increase kda eligiblestats cache

### DIFF
--- a/src/routes.js
+++ b/src/routes.js
@@ -64,7 +64,7 @@ module.exports = (app) => {
   app.get('/kadena/eligible/:days?', cache('5 minutes'), (req, res) => {
     kadenaService.getKadenaEligibleDays(req, res);
   });
-  app.get('/kadena/eligiblestats/:days?', cache('5 minutes'), (req, res) => {
+  app.get('/kadena/eligiblestats/:days?', cache('30 minutes'), (req, res) => {
     kadenaService.getKadenaEligibleStatsDays(req, res);
   });
   app.get('/kadena/availabletimes', cache('5 minutes'), (req, res) => {


### PR DESCRIPTION
I believe this method is only being used by flux economic dashboard, this takes around 45 seconds to complete, so it's a heavy call and for what is needed I believe the increase in cache will be good for the mongodb.