### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/src/services/fluxService.js
+++ b/src/services/fluxService.js
@@ -230,7 +230,7 @@ async function getConnectionsIn(ip, timeout) {
 function getCollateralInfo(collateralOutpoint) {
   const a = collateralOutpoint;
   const b = a.split(', ');
-  const txhash = b[0].substr(10, b[0].length);
+  const txhash = b[0].slice(10);
   const txindex = serviceHelper.ensureNumber(b[1].split(')')[0]);
   return { txhash, txindex };
 }

--- a/src/services/proposalService.js
+++ b/src/services/proposalService.js
@@ -75,8 +75,8 @@ function getLastProposalTxs(transactions) {
           const hexx = encodedMessage.toString(); // force conversion
           // console.log(hexx)
           let strx = '';
-          for (let k = 0; k < hexx.length && hexx.substr(k, 2) !== '00'; k += 2) {
-            strx += String.fromCharCode(parseInt(hexx.substr(k, 2), 16));
+          for (let k = 0; k < hexx.length && hexx.slice(k, k + 2) !== '00'; k += 2) {
+            strx += String.fromCharCode(parseInt(hexx.slice(k, k + 2), 16));
           }
           if (strx !== '') {
             isMessage = strx;


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.