### PR TITLE
Drop the legacy watchtower handling and trim the container detail

### DIFF
--- a/ui/src/pages/Dashboard/NodeInfo/NodeApp.vue
+++ b/ui/src/pages/Dashboard/NodeInfo/NodeApp.vue
@@ -123,13 +123,7 @@
                     :key="index"
                   >
                     <b>Application {{ index + 1 }}:</b> <br>
-                    <b>ID:</b> {{ item.Id }} <br>
                     <b>Names:</b> {{ item.Names }} <br>
-                    <b>Image:</b> {{ item.Image }} <br>
-                    <b>Image ID:</b> {{ item.ImageID }} <br>
-                    <b>Command:</b> {{ item.Command }} <br>
-                    <b>Ports:</b> {{ item.Ports }} <br>
-                    <b>Labels:</b> {{ item.Labels }} <br>
                     <b>State:</b> {{ item.State }} <br>
                     <b>Status:</b> {{ item.Status }} <br>
                   </p>
@@ -223,11 +217,6 @@ export default {
           prop: 'apps.count',
           label: 'Total Application Running',
           minWidth: 150,
-        },
-        {
-          prop: 'apps.fluxtower',
-          label: 'Flux Watch Tower Installed',
-          minWidth: 100,
         },
         {
           prop: 'apps.fluxusage',
@@ -328,24 +317,14 @@ export default {
       this.values.map((value) => {
         let temp;
         const values = value;
-        const filtered = values.apps.runningapps.filter((item) => item.Image !== 'containrrr/watchtower');
-        values.apps.runningapps = filtered;
-        values.apps.fluxtower = filtered.length !== undefined || filtered.length !== 0 ? 'TRUE' : 'FALSE';
-        values.apps.count = filtered.length !== undefined || filtered.length !== 0 ? filtered.length : 0;
+        values.apps.count = values.apps.runningapps.length;
         const appscount = values.apps.count;
-        const appsfluxtower = values.apps.fluxtower;
         temp = this.filter.has(`application running - ${appscount}`) ? this.filter.get(`application running - ${appscount}`) : [];
         if (!this.filter.has(`application running - ${appscount}`)) {
           this.filterValue.push(`application running - ${appscount}`);
         }
         temp.push(values);
         this.filter.set(`application running - ${appscount}`, temp);
-        temp = this.filter.has(`flux watch tower installed - ${appsfluxtower}`) ? this.filter.get(`flux watch tower installed - ${appsfluxtower}`) : [];
-        if (!this.filter.has(`flux watch tower installed - ${appsfluxtower}`)) {
-          this.filterValue.push(`flux watch tower installed - ${appsfluxtower}`);
-        }
-        temp.push(values);
-        this.filter.set(`flux watch tower installed - ${appsfluxtower}`, temp);
         return values;
       });
       this.filters.others = this.filterValue.sort();
@@ -375,7 +354,6 @@ export default {
         values.push({
           ip: !item.ip ? '' : item.ip,
           appsCount: !item.apps.count ? 0 : item.apps.count,
-          fluxTowerInstalled: !item.apps.fluxtower ? '' : item.apps.fluxtower,
           fluxUsage: !item.apps.fluxusage ? '' : item.apps.fluxusage,
           cpuLocked: !item.apps.resources.appsCpusLocked ? '' : item.apps.resources.appsCpusLocked,
           ramLocked: !item.apps.resources.appsRamLocked ? '' : item.apps.resources.appsRamLocked,

--- a/ui/src/pages/Dashboard/NodeInfo/NodeBenchmark.vue
+++ b/ui/src/pages/Dashboard/NodeInfo/NodeBenchmark.vue
@@ -482,10 +482,8 @@ export default {
         const bencharchitecture = values.benchmark.bench.architecture;
         const tier = values.node.status.tier ? values.node.status.tier.toLowerCase() : 'no tier';
         const org = values.geolocation.org.length > 30 ? `${values.geolocation.org.slice(0, 30)}...` : values.geolocation.org;
-        const filtered = values.apps.runningapps.filter((item) => item.Image !== 'containrrr/watchtower');
         values.benchmark.issues = [];
-        values.apps.runningapps = filtered;
-        values.apps.count = filtered.length || filtered.length !== 0 ? filtered.length : 0;
+        values.apps.count = values.apps.runningapps.length;
         values.benchmark.upnp = values.benchmark.bench.ipaddress.includes(':') ? 'TRUE' : 'FALSE';
         values.benchmark.thunder = values.benchmark.bench.thunder ? 'TRUE' : 'FALSE';
         const upnpstatus = values.benchmark.upnp;

--- a/ui/src/pages/Dashboard/Service/CsvService.js
+++ b/ui/src/pages/Dashboard/Service/CsvService.js
@@ -73,7 +73,6 @@ const NodeAddressInfoHeaders = [
 const NodeAppHeaders = [
   'IP Address',
   'Total Application Running',
-  'Flux Tower Installed',
   'Flux Usage',
   'CPU Locked',
   'RAM Locked',

--- a/ui/src/pages/Dashboard/Service/SortService.js
+++ b/ui/src/pages/Dashboard/Service/SortService.js
@@ -364,26 +364,6 @@ const sortNodeApp = (values, sortProps, originalData) => {
       }
       return val;
     });
-  } else if (sortProps.column.label === 'Flux Watch Tower Installed' && sortProps.column.order === 'ascending') {
-    values.sort((a, b) => {
-      let val = 0;
-      if (a.apps.fluxtower > b.apps.fluxtower) {
-        val = 1;
-      } else if (a.apps.fluxtower < b.apps.fluxtower) {
-        val = -1;
-      }
-      return val;
-    });
-  } else if (sortProps.column.label === 'Flux Watch Tower Installed' && sortProps.column.order === 'descending') {
-    values.sort((a, b) => {
-      let val = 0;
-      if (a.apps.fluxtower < b.apps.fluxtower) {
-        val = 1;
-      } else if (a.apps.fluxtower > b.apps.fluxtower) {
-        val = -1;
-      }
-      return val;
-    });
   } else if (sortProps.column.label === 'Flux Usage' && sortProps.column.order === 'ascending') {
     values.sort((a, b) => {
       let val = 0;


### PR DESCRIPTION
Two bits of tidying on the node application view.

## The watchtower handling is dead

FluxOS replaced the watchtower container with its own image update service and removes the container at startup, so the filter here matches nothing.

The flag it fed was also always true:

```js
values.apps.fluxtower = filtered.length !== undefined || filtered.length !== 0 ? 'TRUE' : 'FALSE';
```

`filtered.length !== undefined` cannot be false for an array, so the `||` never evaluates its right side and the ternary never reaches `'FALSE'`. Every node has reported **Flux Watch Tower Installed: TRUE** for as long as that line has existed.

Built on that value were a table column, a filter option, two sort branches in `SortService` and a CSV header. All removed. Application count is now simply the length of the list, which is what it was already trying to be.

## The container detail is trimmed

The expandable per-container rows are reduced to the fields the view actually uses — `Names`, `State`, `Status`. The rest were being rendered because they happened to be in the payload, not because anything reads them.

## One thing to look at in review

`CsvService.NodeAppHeaders` is matched to the export object's keys **by position**, so removing `fluxTowerInstalled` without removing `'Flux Tower Installed'` would have shifted every column right of it and produced a silently wrong export. Both are removed together — 7 headers against 7 keys, in order.

## Files

- `NodeApp.vue` — detail rows, column, filter option, count, CSV key
- `NodeBenchmark.vue` — the same dead filter
- `SortService.js` — the two sort branches
- `CsvService.js` — the header

🤖 Generated with [Claude Code](https://claude.com/claude-code)